### PR TITLE
Accurate ts

### DIFF
--- a/src/capdev-proc.h
+++ b/src/capdev-proc.h
@@ -12,6 +12,7 @@ struct capdev_proc_request_s
 struct capdev_proc_header_s
 {
 	uint64_t channel_mask;
+	uint64_t timestamp;
 	int n_data_bytes;
 	int n_skipped_packets;
 };

--- a/src/source.c
+++ b/src/source.c
@@ -1,5 +1,4 @@
 #include <obs-module.h>
-#include <util/platform.h>
 #include "plugin-macros.generated.h"
 #include "source.h"
 #include "capdev.h"
@@ -114,14 +113,14 @@ static void destroy(void *data)
 	bfree(s);
 }
 
-void source_add_audio(source_t *s, float **data, int n_samples)
+void source_add_audio(source_t *s, float **data, int n_samples, uint64_t timestamp)
 {
 	struct obs_source_audio out = {
 		.speakers = 2,
 		.samples_per_sec = 48000, // TODO: retrieve from the packet
 		.format = AUDIO_FORMAT_FLOAT_PLANAR,
 		.frames = n_samples,
-		.timestamp = os_gettime_ns() - n_samples * 62500 / 3, // * 1000000000 / 48000
+		.timestamp = timestamp,
 	};
 	for (int i = 0; i < 2; i++)
 		out.data[i] = (void *)data[i];

--- a/src/source.h
+++ b/src/source.h
@@ -3,4 +3,4 @@
 #include <stdint.h>
 #include "common.h"
 
-void source_add_audio(source_t *s, float **data, int n_samples);
+void source_add_audio(source_t *s, float **data, int n_samples, uint64_t timestamp);


### PR DESCRIPTION
### Description

- Take timestamp from libpcap
- Estimate offset between the timestamp from libpcap and libobs time
- Calculate libobs's timestamp from the timestamp from libpcap
- Since the estimation takes some time, initial 1024 packets are discarded and not sent to libobs.

### Motivation and Context
There is a buffer in libpcap and libpcap burstly send a lot of packets (roughly 200 packets at my test) at once. That behavior makes difficult to calculate the timestamps for libobs.

### How Has This Been Tested?

Checked the current time of libobs and estimated timestamp for each packet.
![accurate-ts-startup](https://user-images.githubusercontent.com/780600/177046254-b3848db8-b514-4ed1-ab55-1a3d54a1c2ae.svg)

<!-- If unsure, feel free to let them unchecked. -->
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
