### PR TITLE
Fix various bugs on capdev

### DIFF
--- a/src/capdev-proc.c
+++ b/src/capdev-proc.c
@@ -141,6 +141,10 @@ int main(int argc, char **argv)
 
 		struct timeval timeout = {.tv_sec = 0, .tv_usec = fd_pcap >= 0 ? 50000 : 500};
 		int ret = select(nfds, &readfds, NULL, &exceptfds, &timeout);
+		if (ret < 0) {
+			perror("select");
+			ctx.cont = false;
+		}
 
 		if (FD_ISSET(0, &readfds)) {
 			size_t bytes = read(0, &ctx.req, sizeof(ctx.req));

--- a/src/capdev-proc.c
+++ b/src/capdev-proc.c
@@ -174,5 +174,7 @@ int main(int argc, char **argv)
 		}
 	}
 
+	pcap_close(p);
+
 	return 0;
 }

--- a/src/capdev-proc.c
+++ b/src/capdev-proc.c
@@ -144,7 +144,12 @@ int main(int argc, char **argv)
 
 		if (FD_ISSET(0, &readfds)) {
 			size_t bytes = read(0, &ctx.req, sizeof(ctx.req));
-			if (bytes != sizeof(ctx.req)) {
+			if (bytes == 0 || ctx.req.flags & CAPDEV_REQ_FLAG_EXIT) {
+				fprintf(stderr, "Info normal exit '%s'\n", if_name ? if_name : "(null)");
+				ctx.cont = false;
+				break;
+			}
+			else if (bytes != sizeof(ctx.req)) {
 				fprintf(stderr, "Error: read %d bytes, expected %d bytes.\n", (int)bytes,
 					(int)sizeof(ctx.req));
 				ctx.cont = false;

--- a/src/capdev-proc.h
+++ b/src/capdev-proc.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#define CAPDEV_REQ_FLAG_EXIT 1
+
 struct capdev_proc_request_s
 {
 	uint64_t channel_mask;
+	uint32_t flags;
+	uint32_t unused;
 };
 
 struct capdev_proc_header_s

--- a/src/capdev.c
+++ b/src/capdev.c
@@ -440,6 +440,11 @@ static void *thread_main(void *data)
 
 	blog(LOG_INFO, "exiting h8819 thread");
 
+	if (fd_req >= 0) {
+		req.flags |= CAPDEV_REQ_FLAG_EXIT;
+		write(fd_req, &req, sizeof(req));
+	}
+
 	close(fd_req);
 	close(fd_data);
 


### PR DESCRIPTION
This PR contains several fixes.

- capdev: Send exit flag to the sub process
- capdev-proc: Print error message if select failed
- capdev-proc: Close pcap object at the end


<!-- If unsure, feel free to let them unchecked. -->
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [ ] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.
