### PR TITLE
capdev-proc: Apply protocol filter

### DIFF
--- a/src/capdev-proc.c
+++ b/src/capdev-proc.c
@@ -135,6 +135,17 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	struct bpf_program fp = {0};
+	ret = pcap_compile(p, &fp, "ether proto 0x8819", 1, PCAP_NETMASK_UNKNOWN);
+	if (ret) {
+		fprintf(stderr, "Warning: pcap_compile: %s\n", pcap_geterr(p));
+	}
+	else {
+		ret = pcap_setfilter(p, &fp);
+		if (ret)
+			fprintf(stderr, "Error: pcap_setfilter: %s\n", pcap_geterr(p));
+	}
+
 	int fd_pcap = pcap_get_selectable_fd(p);
 
 	struct context_s ctx = {0};


### PR DESCRIPTION
The necessary protocol is only 0x8819. Do not capture other packets.


<!-- If unsure, feel free to let them unchecked. -->
## General checkpoints
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
