### PR TITLE
CI(macOS): Build bundle-type plugin package with universal binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,30 +179,58 @@ jobs:
           set -ex
           . ci/ci_includes.generated.sh
           cmake --install build --config RelWithDebInfo --prefix=release
-          (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
-          cp build/obs-h8819-proc release/${PLUGIN_NAME}/data/
-          cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+          case ${{ matrix.obs }} in
+            27)
+              (cd release/${PLUGIN_NAME} && ../../ci/macos/change-rpath.sh -obs ${{ matrix.obs }} -lib lib/ bin/${PLUGIN_NAME}.so)
+              cp build/obs-h8819-proc release/${PLUGIN_NAME}/data/
+              cp LICENSE release/${PLUGIN_NAME}/data/LICENSE-$PLUGIN_NAME
+              ;;
+            28)
+              (cd release/${PLUGIN_NAME}.plugin/Contents && ../../../ci/macos/change-rpath.sh -obs 28 -lib lib/ bin/${PLUGIN_NAME})
+              cp build/obs-h8819-proc release/${PLUGIN_NAME}.plugin/Contents/Resources/
+              cp LICENSE release/${PLUGIN_NAME}.plugin/Contents/Resources/LICENSE-$PLUGIN_NAME
+              ;;
+          esac
 
       - name: Codesign
         if: ${{ github.event_name != 'pull_request' && steps.setup.outputs.haveCodesignIdent == 'true' }}
         run: |
           . ci/ci_includes.generated.sh
-          for dylib in release/${PLUGIN_NAME}/lib/*.dylib; do
+          set -e
+          for dylib in release/${PLUGIN_NAME}*/lib/*.dylib; do
             test -f "$dylib" || continue
             codesign --remove-signature "$dylib"
           done
-          for dylib in release/${PLUGIN_NAME}/*/*.{so,dylib}; do
-            test -f "$dylib" || continue
+          case ${{ matrix.obs }} in
+            27)
+              files=(
+                release/${PLUGIN_NAME}/bin/${PLUGIN_NAME}.so
+                $(ls release/${PLUGIN_NAME}/*/*.dylib || :)
+              )
+              codesign --force --options runtime --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" release/${PLUGIN_NAME}/data/obs-h8819-proc
+              ;;
+            28)
+              files=(
+                release/${PLUGIN_NAME}.plugin/Contents/MacOS/${PLUGIN_NAME}
+                $(ls release/${PLUGIN_NAME}.plugin/*/*.dylib || :)
+              )
+              codesign --force --options runtime --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" release/${PLUGIN_NAME}.plugin/Contents/Resources/obs-h8819-proc
+              ;;
+          esac
+          for dylib in "${files[@]}"; do
             codesign --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" "$dylib"
           done
-          codesign --force --options runtime --sign "${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}" release/${PLUGIN_NAME}/data/obs-h8819-proc
 
       - name: Package
         run: |
           . ci/ci_includes.generated.sh
+          set -ex
           zipfile=$PWD/package/${PLUGIN_NAME}${PKG_SUFFIX}.zip
           mkdir package
-          (cd release/ && zip -r $zipfile $PLUGIN_NAME)
+          case ${{ matrix.obs }} in
+            27) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}) ;;
+            28) (cd release/ && zip -r $zipfile ${PLUGIN_NAME}.plugin) ;;
+          esac
           ci/macos/install-packagesbuild.sh
           packagesbuild \
             --build-folder $PWD/package/ \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,6 +151,17 @@ jobs:
           GIT_TAG=$(git describe --tags --always)
           PKG_SUFFIX=-${GIT_TAG}-obs${{ matrix.obs }}-macos-${{ matrix.arch }}
           set -e
+          case "${{ matrix.obs }}" in
+            27)
+              cmake_opt=()
+              ;;
+            28)
+              cmake_opt=(
+                -D MACOSX_PLUGIN_BUNDLE_TYPE=BNDL
+                -D OBS_BUNDLE_CODESIGN_IDENTITY='${{ secrets.MACOS_SIGNING_APPLICATION_IDENTITY }}'
+              )
+              ;;
+          esac
           cmake -S . -B build -G Ninja \
             -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -158,7 +169,8 @@ jobs:
             -DCMAKE_OSX_ARCHITECTURES=$arch \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
             -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
-            -D PKG_SUFFIX=$PKG_SUFFIX
+            -D PKG_SUFFIX=$PKG_SUFFIX \
+            "${cmake_opt[@]}"
           cmake --build build --config RelWithDebInfo
           echo "PKG_SUFFIX='$PKG_SUFFIX'" >> ci/ci_includes.generated.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
           - obs: 27
             arch: x86_64
           - obs: 28
-            arch: arm64
+            arch: universal
     defaults:
       run:
         shell: bash
@@ -166,7 +166,7 @@ jobs:
             -D QT_VERSION=$OBS_QT_VERSION_MAJOR \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DCMAKE_PREFIX_PATH="$PWD/release/" \
-            -DCMAKE_OSX_ARCHITECTURES=$arch \
+            -DCMAKE_OSX_ARCHITECTURES=${arch/#universal/x86_64;arm64} \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} \
             -DCMAKE_FRAMEWORK_PATH="$deps/Frameworks;$deps/lib/cmake;$deps" \
             -D PKG_SUFFIX=$PKG_SUFFIX \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ if(APPLE)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fvisibility=default")
 
 	set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES PREFIX "")
+	set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
+	set(MACOSX_PLUGIN_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
+	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
 
 	configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,8 +98,8 @@ if(APPLE)
 	set(MACOSX_PLUGIN_GUI_IDENTIFIER "${MACOS_BUNDLEID}")
 	set(MACOSX_PLUGIN_BUNDLE_VERSION "${CMAKE_PROJECT_VERSION}")
 	set(MACOSX_PLUGIN_SHORT_VERSION_STRING "1")
-
-	configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)
 endif()
 
 setup_plugin_target(${CMAKE_PROJECT_NAME})
+
+configure_file(installer/installer-macOS.pkgproj.in installer-macOS.generated.pkgproj)

--- a/ci/forum-update-info.json
+++ b/ci/forum-update-info.json
@@ -1,0 +1,3 @@
+{
+	"plugin_url": "https://obsproject.com/forum/resources/reac-audio-source.1471/"
+}

--- a/cmake/ObsPluginHelpers.cmake
+++ b/cmake/ObsPluginHelpers.cmake
@@ -110,6 +110,32 @@ if(OS_MACOS)
 	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH OFF)
 
 	function(setup_plugin_target target)
+		if(NOT DEFINED MACOSX_PLUGIN_GUI_IDENTIFIER)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_GUI_IDENTIFIER' set, but is required to build plugin bundles on macOS - example: 'com.yourname.pluginname'"
+				)
+		endif()
+
+		if(NOT DEFINED MACOSX_PLUGIN_BUNDLE_VERSION)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_BUNDLE_VERSION' set, but is required to build plugin bundles on macOS - example: '25'"
+				)
+		endif()
+
+		if(NOT DEFINED MACOSX_PLUGIN_SHORT_VERSION_STRING)
+			message(
+				FATAL_ERROR
+				"No 'MACOSX_PLUGIN_SHORT_VERSION_STRING' set, but is required to build plugin bundles on macOS - example: '1.0.2'"
+				)
+		endif()
+
+		set(MACOSX_PLUGIN_BUNDLE_NAME "${target}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_BUNDLE_VERSION "${MACOSX_BUNDLE_BUNDLE_VERSION}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_SHORT_VERSION_STRING "${MACOSX_BUNDLE_SHORT_VERSION_STRING}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_EXECUTABLE_NAME "${target}" PARENT_SCOPE)
+		set(MACOSX_PLUGIN_BUNDLE_TYPE "BNDL" PARENT_SCOPE)
 
 		install(
 			TARGETS ${target}

--- a/cmake/bundle/macos/Plugin-Info.plist.in
+++ b/cmake/bundle/macos/Plugin-Info.plist.in
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleName</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_PLUGIN_GUI_IDENTIFIER}</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_VERSION}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_PLUGIN_SHORT_VERSION_STRING}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_PLUGIN_EXECUTABLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>${MACOSX_PLUGIN_BUNDLE_TYPE}</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>LSMinimumSystemVersion</key>
+	<string>10.13</string>
+</dict>
+</plist>

--- a/cmake/bundle/macos/entitlements.plist
+++ b/cmake/bundle/macos/entitlements.plist
@@ -1,0 +1,17 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+        <true/>
+        <key>com.apple.security.device.camera</key>
+        <true/>
+        <key>com.apple.security.device.audio-input</key>
+        <true/>
+        <key>com.apple.security.cs.disable-library-validation</key>
+        <true/>
+        <!-- Allows @executable_path to load libaries from within the .app bundle. -->
+        <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+        <true/>
+    </dict>
+</plist>

--- a/installer/installer-macOS.pkgproj.in
+++ b/installer/installer-macOS.pkgproj.in
@@ -63,7 +63,7 @@
 															<key>GID</key>
 															<integer>80</integer>
 															<key>PATH</key>
-															<string>../@RELATIVE_INSTALL_PATH@/@CMAKE_PROJECT_NAME@</string>
+															<string>../@RELATIVE_INSTALL_PATH@/@CMAKE_PROJECT_NAME@@FIRST_DIR_SUFFIX@</string>
 															<key>PATH_TYPE</key>
 															<integer>1</integer>
 															<key>PERMISSIONS</key>


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->
From OBS 28.0-rc1 for macOS on arm64, the old directory structure is not accepted.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
- [x] Check log files to confirm codesign is done.
- [x] Run with OBS 28.0-rc1 on Intel mac.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
