### PR TITLE
Add option to save raw packets to file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PLUGIN_AUTHOR "Norihiro Kamae")
 set(MACOS_BUNDLEID "net.nagater.obs-h8819-source")
 set(MACOS_PACKAGE_UUID "FAA836AE-8D20-4F85-AC53-34EB8BD1D652")
 set(MACOS_INSTALLER_UUID "E44BD56C-036E-480A-AE87-DAB6DBCFECF9")
+set(PLUGIN_URL "https://obsproject.com/forum/resources/reac-audio-source.1471/")
 set(ID_PREFIX "net.nagater.obs-h8819-source.")
 
 # Replace `me@contoso.com` with the maintainer email address you want to put in Linux packages

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,9 +78,13 @@ if(NOT OS_WINDOWS)
 	add_executable(obs-h8819-proc
 		src/capdev-proc.c
 		src/capdev-proc.h
+		src/pcap-dump-thread.cc
+		src/pcap-dump-thread.h
 	)
 
-	target_link_libraries(obs-h8819-proc pcap)
+	target_compile_features(obs-h8819-proc PRIVATE cxx_std_17)
+
+	target_link_libraries(obs-h8819-proc pcap pthread)
 endif()
 
 if(OS_WINDOWS)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ Available devices will be listed on the popup list.
 Specify left and right channel to be captured.
 Available range is 1 to 40.
 
+### Save to file
+*Not available on Windows*
+Enables to save raw packets into a pcap capture file.
+
+### Save file name format
+*Not available on Windows*
+Specifies file name format to save.
+Format strings are same as the recording files of OBS.
+This file name format should be absoluted path. An extension `.pcap` will be added automatically.
+
 ## Build and install
 ### Linux
 Use cmake to build on Linux. After checkout, run these commands.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ Enables to save raw packets into a pcap capture file.
 *Not available on Windows*
 Specifies file name format to save.
 Format strings are same as the recording files of OBS.
-This file name format should be absoluted path. An extension `.pcap` will be added automatically.
+This file name format should be absoluted path.
+
+Note: For OBS 29.0 and older, an extension `.pcap` will be added automatically.
 
 ## Build and install
 ### Linux

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -3,3 +3,5 @@
 "Channel Left"="Channel Left"
 "Channel Right"="Channel Right"
 AsyncCompensation="Enable Asynchronous Compensation"
+Prop.SaveFile="Save to file"
+Prop.SaveFileFormat="Save file name format"

--- a/installer/installer-Windows.iss.in
+++ b/installer/installer-Windows.iss.in
@@ -1,7 +1,7 @@
 #define MyAppName "@CMAKE_PROJECT_NAME@"
 #define MyAppVersion "@CMAKE_PROJECT_VERSION@"
 #define MyAppPublisher "@PLUGIN_AUTHOR@"
-#define MyAppURL "http://www.mywebsite.com"
+#define MyAppURL "@PLUGIN_URL@"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.

--- a/src/capdev-common.c
+++ b/src/capdev-common.c
@@ -192,7 +192,7 @@ static bool capdev_can_save_file_unlocked(capdev_t *dev, source_t *src)
 
 static inline void capdev_save_file_unlocked(capdev_t *dev, source_t *src, const char *name)
 {
-	if (!capdev_can_save_file_unlocked(dev, src))
+	if (name && !capdev_can_save_file_unlocked(dev, src))
 		return;
 
 	struct source_list_s *item = source_to_item_unlocked(dev, src);

--- a/src/capdev-common.c
+++ b/src/capdev-common.c
@@ -140,6 +140,15 @@ void capdev_link_source(capdev_t *dev, source_t *src, const int *channels)
 	pthread_mutex_unlock(&dev->mutex);
 }
 
+static struct source_list_s *source_to_item_unlocked(capdev_t *dev, source_t *src)
+{
+	for (struct source_list_s *item = dev->sources; item; item = item->next) {
+		if (item->src == src)
+			return item;
+	}
+	return NULL;
+}
+
 static void recalculate_channel_mask_unlocked(capdev_t *dev)
 {
 	uint64_t channel_mask = 0;
@@ -153,20 +162,17 @@ void capdev_update_source(capdev_t *dev, source_t *src, const int *channels)
 {
 	pthread_mutex_lock(&dev->mutex);
 
-	for (struct source_list_s *item = dev->sources; item; item = item->next) {
-		if (item->src != src)
-			continue;
-
+	struct source_list_s *item = source_to_item_unlocked(dev, src);
+	if (item) {
 		item->channel_mask = channels_to_mask(channels);
 		for (item->n_channels = 0; item->n_channels < N_CHANNELS; item->n_channels++) {
 			if (channels[item->n_channels] < 0)
 				break;
 			item->channels[item->n_channels] = channels[item->n_channels];
 		}
-		break;
-	}
 
-	recalculate_channel_mask_unlocked(dev);
+		recalculate_channel_mask_unlocked(dev);
+	}
 
 	pthread_mutex_unlock(&dev->mutex);
 }
@@ -189,10 +195,8 @@ static inline void capdev_save_file_unlocked(capdev_t *dev, source_t *src, const
 	if (!capdev_can_save_file_unlocked(dev, src))
 		return;
 
-	for (struct source_list_s *item = dev->sources; item; item = item->next) {
-		if (item->src != src)
-			continue;
-
+	struct source_list_s *item = source_to_item_unlocked(dev, src);
+	if (item) {
 		if (name && item->filename && strcmp(name, item->filename) == 0)
 			return;
 		if (!name && !item->filename)
@@ -200,7 +204,6 @@ static inline void capdev_save_file_unlocked(capdev_t *dev, source_t *src, const
 
 		bfree(item->filename);
 		item->filename = name ? bstrdup(name) : NULL;
-		return;
 	}
 }
 
@@ -223,19 +226,16 @@ void capdev_unlink_source(capdev_t *dev, source_t *src)
 {
 	pthread_mutex_lock(&dev->mutex);
 
-	for (struct source_list_s *item = dev->sources; item; item = item->next) {
-		if (item->src != src)
-			continue;
-
+	struct source_list_s *item = source_to_item_unlocked(dev, src);
+	if (item) {
 		*item->prev_next = item->next;
 		if (item->next)
 			item->next->prev_next = item->prev_next;
 		bfree(item->filename);
 		bfree(item);
-		break;
-	}
 
-	recalculate_channel_mask_unlocked(dev);
+		recalculate_channel_mask_unlocked(dev);
+	}
 
 	pthread_mutex_unlock(&dev->mutex);
 }

--- a/src/capdev-internal.h
+++ b/src/capdev-internal.h
@@ -9,6 +9,7 @@ struct source_list_s
 	uint64_t channel_mask;
 	size_t n_channels;
 	int channels[N_CHANNELS];
+	char *filename;
 
 	struct source_list_s *next;
 	struct source_list_s **prev_next;

--- a/src/capdev-proc.c
+++ b/src/capdev-proc.c
@@ -235,7 +235,12 @@ int main(int argc, char **argv)
 				size_t len = ctx.req.unused;
 				char *name = malloc(len + 1);
 				name[len] = 0;
-				read(0, name, len);
+				ssize_t len_read = read(0, name, len);
+				if (len_read != len) {
+					fprintf(stderr, "Error: read %zd bytes, expected %zu bytes.\n", len_read, len);
+					ctx.cont = false;
+					break;
+				}
 				fprintf(stderr, "Info: preparing to dump file '%s'\n", name);
 				pdt = pcap_dump_thread_create(p, name);
 				free(name);

--- a/src/capdev-proc.h
+++ b/src/capdev-proc.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #define CAPDEV_REQ_FLAG_EXIT 1
+#define CAPDEV_REQ_FLAG_SAVE 2
+#define CAPDEV_REQ_FLAG_SAVE_FILENAME 4
 
 struct capdev_proc_request_s
 {

--- a/src/capdev.h
+++ b/src/capdev.h
@@ -9,6 +9,8 @@ void capdev_release(capdev_t *dev);
 
 void capdev_link_source(capdev_t *dev, source_t *src, const int *channels);
 void capdev_update_source(capdev_t *dev, source_t *src, const int *channels);
+void capdev_save_file(capdev_t *dev, source_t *src, const char *name);
+bool capdev_can_save_file(capdev_t *dev, source_t *src);
 void capdev_unlink_source(capdev_t *dev, source_t *src);
 
 void capdev_enum_devices(void (*cb)(const char *name, const char *description, void *param), void *param);

--- a/src/pcap-dump-thread.cc
+++ b/src/pcap-dump-thread.cc
@@ -19,7 +19,9 @@ struct packet
 	packet() {}
 	packet(const struct pcap_pkthdr *h, const uint8_t *p) : header(*h)
 	{
-		memcpy(payload, p, std::min((size_t)h->caplen, sizeof(payload)));
+		if (header.caplen > sizeof(payload))
+			header.caplen = sizeof(payload);
+		memcpy(payload, p, header.caplen);
 	}
 };
 

--- a/src/pcap-dump-thread.cc
+++ b/src/pcap-dump-thread.cc
@@ -1,0 +1,110 @@
+#include <stdio.h>
+#include <string>
+#include <cstring>
+#include <list>
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <condition_variable>
+#include <pcap.h>
+#include "pcap-dump-thread.h"
+
+#define PAYLOAD_SIZE 1500
+
+struct packet
+{
+	struct pcap_pkthdr header;
+	uint8_t payload[PAYLOAD_SIZE];
+
+	packet() {}
+	packet(const struct pcap_pkthdr *h, const uint8_t *p) : header(*h)
+	{
+		memcpy(payload, p, std::min((size_t)h->caplen, sizeof(payload)));
+	}
+};
+
+struct pcap_dump_thread
+{
+	// configurations set at creation
+	std::string filename;
+	pcap_t *p;
+
+	// data to pass between threads
+	std::list<packet> packets;
+	std::mutex mutex;
+	std::condition_variable cond;
+	volatile bool stop = false;
+	std::thread thread;
+};
+
+static void pcap_dump_thread_thread(pcap_dump_thread_t *);
+
+pcap_dump_thread_t *pcap_dump_thread_create(pcap_t *p, const char *filename)
+{
+	auto *ctx = new pcap_dump_thread;
+	ctx->filename = filename;
+	ctx->p = p;
+
+	ctx->thread = std::thread([ctx]() { pcap_dump_thread_thread(ctx); });
+
+	return ctx;
+}
+
+void pcap_dump_thread_stop(pcap_dump_thread_t *ctx)
+{
+	std::unique_lock<std::mutex> lock(ctx->mutex);
+	ctx->stop = true;
+
+	lock.unlock();
+	ctx->cond.notify_one();
+}
+
+void pcap_dump_thread_release(pcap_dump_thread_t *ctx)
+{
+	if (!ctx)
+		return;
+
+	pcap_dump_thread_stop(ctx);
+
+	ctx->thread.join();
+	fprintf(stderr, "Info: cleaned up to dump file '%s'\n", ctx->filename.c_str());
+	delete ctx;
+}
+
+void pcap_dump_thread_dump(pcap_dump_thread_t *ctx, const struct pcap_pkthdr *header, const uint8_t *payload)
+{
+	std::unique_lock<std::mutex> lock(ctx->mutex);
+
+	ctx->packets.emplace_back(header, payload);
+
+	lock.unlock();
+	ctx->cond.notify_one();
+}
+
+void pcap_dump_thread_thread(pcap_dump_thread_t *ctx)
+{
+	fprintf(stderr, "Info: opening a dump file '%s'\n", ctx->filename.c_str());
+	pcap_dumper_t *pd = pcap_dump_open(ctx->p, ctx->filename.c_str());
+
+	packet pkt;
+
+	while (!ctx->stop) {
+		{
+			std::unique_lock<std::mutex> lock(ctx->mutex);
+			ctx->cond.wait(lock, [ctx] { return ctx->stop || ctx->packets.size(); });
+
+			if (!ctx->packets.size())
+				continue;
+
+			pkt = *ctx->packets.begin();
+			ctx->packets.pop_front();
+		}
+
+		if (pd) {
+			pcap_dump((u_char *)pd, &pkt.header, pkt.payload);
+		}
+	}
+
+	fprintf(stderr, "Info: closing the dump file '%s'\n", ctx->filename.c_str());
+	pcap_dump_close(pd);
+}

--- a/src/pcap-dump-thread.h
+++ b/src/pcap-dump-thread.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef struct pcap_dump_thread pcap_dump_thread_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+pcap_dump_thread_t *pcap_dump_thread_create(pcap_t *p, const char *filename);
+void pcap_dump_thread_stop(pcap_dump_thread_t *);
+void pcap_dump_thread_release(pcap_dump_thread_t *);
+void pcap_dump_thread_dump(pcap_dump_thread_t *, const struct pcap_pkthdr *header, const uint8_t *payload);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/src/source.c
+++ b/src/source.c
@@ -89,6 +89,12 @@ static void update_channels(struct source_s *s, int channel_l, int channel_r)
 	s->channel_r = channel_r;
 }
 
+#if LIBOBS_API_VER >= MAKE_SEMANTIC_VERSION(29, 1, 0)
+#define FMTEXT NULL
+#else
+#define FMTEXT (obs_get_version() >= MAKE_SEMANTIC_VERSION(29, 1, 0) ? NULL : "pcap")
+#endif
+
 static void update_save_file(struct source_s *s, bool save, const char *save_filename_fmt, bool force)
 {
 	if (!save) {
@@ -105,7 +111,7 @@ static void update_save_file(struct source_s *s, bool save, const char *save_fil
 
 	bfree(s->save_filename_fmt);
 	s->save_filename_fmt = bstrdup(save_filename_fmt);
-	char *save_filename = os_generate_formatted_filename("pcap", false, save_filename_fmt);
+	char *save_filename = os_generate_formatted_filename(FMTEXT, false, save_filename_fmt);
 	capdev_save_file(s->capdev, s, save_filename);
 	bfree(save_filename);
 }


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Save captured packets to a file so that all audio will be post processed.

Limitations:
- Currently, only implemented for macOS and Linux.
- If multiple sources associating to a device enable the option, only one setting will be effective.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested on Fedora 37.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [ ] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
