### PR TITLE
Add a property async_compensation to switch asynchronous SRC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ID_PREFIX "net.nagater.obs-h8819-source.")
 set(LINUX_MAINTAINER_EMAIL "norihiro@nagater.net")
 
 option(ENABLE_COVERAGE "Enable coverage option for GCC" OFF)
+option(ENABLE_ASYNC_COMPENSATION "Enable async-compensation property for the PR 6351" OFF)
 
 # TAKE NOTE: No need to edit things past this point
 

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -2,3 +2,4 @@
 "Ethernet device"="Ethernet device"
 "Channel Left"="Channel Left"
 "Channel Right"="Channel Right"
+AsyncCompensation="Enable Asynchronous Compensation"

--- a/data/locale/ja-JP.ini
+++ b/data/locale/ja-JP.ini
@@ -2,3 +2,4 @@
 "Ethernet device"="イーサネットデバイス"
 "Channel Left"="左チャンネル"
 "Channel Right"="右チャンネル"
+AsyncCompensation="非同期補償を有効にする"

--- a/src/plugin-macros.h.in
+++ b/src/plugin-macros.h.in
@@ -27,6 +27,8 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #cmakedefine OS_LINUX
 #cmakedefine OS_MACOS
 
+#cmakedefine ENABLE_ASYNC_COMPENSATION
+
 #define blog(level, msg, ...) blog(level, "[" PLUGIN_NAME "] " msg, ##__VA_ARGS__)
 
 #endif // PLUGINNAME_H

--- a/src/source.c
+++ b/src/source.c
@@ -40,6 +40,9 @@ static obs_properties_t *get_properties(void *data)
 	capdev_enum_devices(device_name_enum_cb, prop);
 	obs_properties_add_int(props, "channel_l", obs_module_text("Channel Left"), 1, 40, 1);
 	obs_properties_add_int(props, "channel_r", obs_module_text("Channel Right"), 1, 40, 1);
+#ifdef ENABLE_ASYNC_COMPENSATION
+	obs_properties_add_bool(props, "async_compensation", obs_module_text("AsyncCompensation"));
+#endif
 
 	return props;
 }
@@ -98,6 +101,10 @@ static void update(void *data, obs_data_t *settings)
 
 	if (channel_l != s->channel_l || channel_r != s->channel_r)
 		update_channels(s, channel_l, channel_r);
+
+#ifdef ENABLE_ASYNC_COMPENSATION
+	obs_source_set_async_compensation(s->context, obs_data_get_bool(settings, "async_compensation"));
+#endif
 }
 
 static void *create(obs_data_t *settings, obs_source_t *source)


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

This commit implements a property to enable asynchronous sample rate
conversion (SRC) in the PR 6351.

This commit relies on the PR so that the implementation is disabled by default.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Tested on Fedora 38.

Used tcpreplay to send REAC packets.

Received REAC audio for around 2 minutes.

Checked the log shows the lines below.
```text
[obs-h8819-source] exiting h8819 thread
[obs-h8819-source] exit h8819 proc 0
[obs-h8819-source] h8819[enp0s31f6]: 524866 packets received, 0 packets dropped
audio_resampler: input 6286092 samples, output 6296438 samples, estimated input frequency 47921.006967 Hz
```

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
