### PR TITLE
ci/windows: Upgrade npcap-sdk version to 1.16

### DIFF
--- a/ci/windows/install-npcap.sh
+++ b/ci/windows/install-npcap.sh
@@ -2,9 +2,9 @@
 
 set -ex
 
-curl -O https://npcap.com/dist/npcap-sdk-1.15.zip
-sha256sum -c <<<'52c7b9fb4abee3ad9fe739bb545c3efe77b731c8e127122bdf328eafdae3ed4f npcap-sdk-1.15.zip'
-7z x npcap-sdk-1.15.zip
+curl -O https://npcap.com/dist/npcap-sdk-1.16.zip
+sha256sum -c <<<'f0a8be7778ee3ae1b99bbbecb27a3ff0f6c111a4093f1c78c5c5a099607184db npcap-sdk-1.16.zip'
+7z x npcap-sdk-1.16.zip
 
 function path_unix2win
 {


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

Upgrade npcap SDK library from 1.15 to 1.16.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

- [x] Tested on OBS 32.1 RC1 + Windows 10.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [ ] The commit is compatible with repository's license.

See also #25.
